### PR TITLE
Update search to work with angular@14 builds

### DIFF
--- a/wordpress/wp-content/themes/linklives/resources/views/template-search.blade.php
+++ b/wordpress/wp-content/themes/linklives/resources/views/template-search.blade.php
@@ -22,12 +22,9 @@
     <style>
       @import url("https://dx7i5z2o95p3n.cloudfront.net/frontend/styles.css");
     </style>
-    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/runtime-es2015.js" type="module"></script>
-    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/runtime-es5.js" nomodule="" defer=""></script>
-    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/polyfills-es5.js" nomodule="" defer=""></script>
-    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/polyfills-es2015.js" type="module"></script>
-    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/main-es2015.js" type="module"></script>
-    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/main-es5.js" nomodule="" defer=""></script>
+    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/runtime.js"></script>
+    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/polyfills.js"></script>
+    <script src="https://dx7i5z2o95p3n.cloudfront.net/frontend/main.js"></script>
 
   @endwhile
 


### PR DESCRIPTION
This PR is pending until the angular 14 update to [linklives-frontend](https://github.com/CopenhagenCityArchives/linklives-frontend) is deployed to production. This PR must be merged in order to target the updated build files.

In short: ES5 support was dropped as Internet Explorer support was dropped from Angular, which means specific build targets (es5, es2015) are no longer needed.